### PR TITLE
Don't overwrite $prefix if already bound

### DIFF
--- a/sensible.tmux
+++ b/sensible.tmux
@@ -132,7 +132,9 @@ main() {
 		fi
 
 		# pressing `prefix + prefix` sends <prefix> to the shell
-		tmux bind-key "$prefix" send-prefix
+		if key_binding_not_set "$prefix"; then
+			tmux bind-key "$prefix" send-prefix
+		fi
 	fi
 
 	# If Ctrl-a is prefix then `Ctrl-a + a` switches between alternate windows.


### PR DESCRIPTION
I have the following in .tmux.conf:

``` conf
unbind C-b
set -g prefix C-Space

# quickly switch between panes
bind C-Space select-pane -t :.+

set -g @tpm_plugins "              \
  tmux-plugins/tpm                 \
  tmux-plugins/tmux-sensible       \
"
run-shell ~/.tmux/plugins/tpm/tpm
```

When tmux-sensible gets loaded, it overwrites my existing C-Space binding.
