### PR TITLE
Allow n/p to be repeated while holding down ctrl

### DIFF
--- a/sensible.tmux
+++ b/sensible.tmux
@@ -147,12 +147,12 @@ main() {
 		tmux bind-key "$prefix_without_ctrl" last-window
 	fi
 
-	# easier switching between next/prev window
+	# even easier switching between next/prev window
 	if key_binding_not_set "C-p"; then
-		tmux bind-key C-p previous-window
+		tmux bind-key -r C-p previous-window
 	fi
 	if key_binding_not_set "C-n"; then
-		tmux bind-key C-n next-window
+		tmux bind-key -r C-n next-window
 	fi
 
 	# source `.tmux.conf` file - as suggested in `man tmux`


### PR DESCRIPTION
...and tapping n or p

Instead of having to tap an an an or ap ap ap while holding control, you
just do ctrl-a (in my case) and then hold control and tap n n n or p p p

Also, I think my code below will work, but the actual bindings I have are:

```
# Quick pane selection
bind -r C-p select-window -t :-
bind -r C-n select-window -t :+
```
