### PR TITLE
Change common commands to mirror other popular terminal multiplexers.

### DIFF
--- a/sensible.tmux
+++ b/sensible.tmux
@@ -133,14 +133,14 @@ main() {
 
 		# pressing `prefix + prefix` sends <prefix> to the shell
 		if key_binding_not_set "$prefix"; then
-			tmux bind-key "$prefix" send-prefix
+			tmux bind-key "$prefix" last-window
 		fi
 	fi
 
 	# If Ctrl-a is prefix then `Ctrl-a + a` switches between alternate windows.
 	# Works for any prefix character.
 	if key_binding_not_set "$prefix_without_ctrl"; then
-		tmux bind-key "$prefix_without_ctrl" last-window
+		tmux bind-key "$prefix_without_ctrl" send-prefix
 	fi
 
 	# easier switching between next/prev window


### PR DESCRIPTION
Many people come to tmux after having used other popular terminal multiplexers. These people will often have a substantial amount of muscle memory related to the key-bindings of their previous multiplexer. Key-bindings for common actions in tmux should try to make use of this established muscle memory unless there is a compelling reason not to do so.