### PR TITLE
Fixed key_binding_not_set regex issue

### DIFF
--- a/sensible.tmux
+++ b/sensible.tmux
@@ -45,8 +45,7 @@ server_option_value_not_changed() {
 }
 
 key_binding_not_set() {
-	local key="$1"
-	if [[ ${key} == '\' ]]; then key='\\'; fi
+	local key="${1//\\/\\\\}"
 	if $(tmux list-keys | grep -q "${KEY_BINDING_REGEX}${key}[[:space:]]"); then
 		return 1
 	else

--- a/sensible.tmux
+++ b/sensible.tmux
@@ -46,6 +46,7 @@ server_option_value_not_changed() {
 
 key_binding_not_set() {
 	local key="$1"
+	if [[ ${key} == '\' ]]; then key='\\'; fi
 	if $(tmux list-keys | grep -q "${KEY_BINDING_REGEX}${key}[[:space:]]"); then
 		return 1
 	else


### PR DESCRIPTION
If you run key_binding_not_set against '\' that character will be placed
as is in the regex that's run, and will escape something it shouldn't.
So we test for this and escape the character if necessary.

Fixes #36 
