### PR TITLE
Fix 'obsolte' typo

### DIFF
--- a/sensible.tmux
+++ b/sensible.tmux
@@ -126,7 +126,7 @@ main() {
 
 	# if C-b is not prefix
 	if [ $prefix != "C-b" ]; then
-		# unbind obsolte default binding
+		# unbind obsolete default binding
 		if key_binding_not_changed "C-b" "send-prefix"; then
 			tmux unbind-key C-b
 		fi


### PR DESCRIPTION
Just a minor typo fix, hope that's all right.

Thanks for making tmux-sensible, it's nice both as a plugin and as inspiration 👍 