### PR TITLE
Swap last-window & send-prefix bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ### master
+- swap `last-window` & `send-prefix` bindings
 - remove `detach-on-destroy`
 - do not set `aggressive-resize` on iTerm terminal
 - disable `detach-on-destroy`

--- a/README.md
+++ b/README.md
@@ -72,8 +72,8 @@ allowing you to hold `Ctrl` and repeat `a + p`/`a + n` (if your prefix is
 "Adaptable" key bindings that build upon your `prefix` value:
 
     # if prefix is 'C-a'
-    bind C-a send-prefix
-    bind a last-window
+    bind C-a last-window
+    bind a send-prefix
 
 If prefix is `C-b`, above keys will be `C-b` and `b`.<br/>
 If prefix is `C-z`, above keys will be `C-z` and `z`... you get the idea.

--- a/sensible.tmux
+++ b/sensible.tmux
@@ -131,16 +131,16 @@ main() {
 			tmux unbind-key C-b
 		fi
 
-		# pressing `prefix + prefix` sends <prefix> to the shell
+		# pressing `Ctrl-prefix + prefix` sends <prefix> to the shell
 		if key_binding_not_set "$prefix"; then
-			tmux bind-key "$prefix" send-prefix
+			tmux bind-key "$prefix_without_ctrl" send-prefix
 		fi
 	fi
 
-	# If Ctrl-a is prefix then `Ctrl-a + a` switches between alternate windows.
+	# If Ctrl-a is prefix then `Ctrl-a + Ctrl-a` switches between alternate windows.
 	# Works for any prefix character.
 	if key_binding_not_set "$prefix_without_ctrl"; then
-		tmux bind-key "$prefix_without_ctrl" last-window
+		tmux bind-key "$prefix" last-window
 	fi
 
 	# easier switching between next/prev window


### PR DESCRIPTION
C-a is last-window, a is send-prefix.

This is consistent with screen bindings; C-a C-a toggles to last window,
and C-a a sends the command character.

last-window is usually also needed more often, so it makes sense to make
it more accessible.

Fixes #40.