### PR TITLE
Easier navigation in zero based windowing

### DIFF
--- a/sensible.tmux
+++ b/sensible.tmux
@@ -151,6 +151,11 @@ main() {
 		tmux bind-key C-n next-window
 	fi
 
+	# Easier navigation in zero based windowing
+	if key_binding_not_set '`' && option_value_not_changed "base-index" "0"; then
+		tmux bind-key '`' select-window -t 0
+	fi
+
 	# source `.tmux.conf` file - as suggested in `man tmux`
 	if key_binding_not_set "R"; then
 		tmux bind-key R run-shell ' \


### PR DESCRIPTION
In the tmux windowing env we can select windows using prefix-NUM. However with zero being the first window but on the opposite side of the keyboard, it can be counter-intuitive.

I propose that the backtick '`' be used for window in the zero position. 

prefix-` -> window 0
prefix-1 -> window 1
prefix-2 -> window 2
etc