### PR TITLE
Fix iTerm2 terminal detection

### DIFF
--- a/sensible.tmux
+++ b/sensible.tmux
@@ -11,7 +11,7 @@ is_osx() {
 }
 
 iterm_terminal() {
-	[[ "$TERM_PROGRAM" =~ ^iTerm ]]
+	[[ "${TERM_PROGRAM}" =~ ^iTerm || "${LC_TERMINAL}" =~ ^iTerm ]]
 }
 
 command_exists() {


### PR DESCRIPTION
Fixes https://github.com/tmux-plugins/tmux-sensible/issues/24#issuecomment-643806879:

> Ps. A proper fix would be for tmux-sensible to also listen to LC_TERMINAL (which iTerm automatically sends over ssh)