### PR TITLE
XDG-friendly config reload

### DIFF
--- a/sensible.tmux
+++ b/sensible.tmux
@@ -64,6 +64,15 @@ key_binding_not_changed() {
 	fi
 }
 
+get_tmux_config() {
+	local tmux_config_xdg="${XDG_CONFIG_HOME:-$HOME/.config}/tmux/tmux.conf"
+	local tmux_config="$HOME/.tmux.conf"
+
+	[[ -f "${tmux_config_xdg}" ]] && tmux_config=${tmux_config_xdg}
+
+	echo ${tmux_config}
+}
+
 main() {
 	# OPTIONS
 
@@ -147,9 +156,11 @@ main() {
 
 	# source `.tmux.conf` file - as suggested in `man tmux`
 	if key_binding_not_set "R"; then
-		tmux bind-key R run-shell ' \
-			tmux source-file ~/.tmux.conf > /dev/null; \
-			tmux display-message "Sourced .tmux.conf!"'
+		local tmux_config=$(get_tmux_config)
+
+		tmux bind-key R run-shell " \
+			tmux source-file ${tmux_config} > /dev/null; \
+			tmux display-message 'Sourced ${tmux_config}!'"
 	fi
 }
 main


### PR DESCRIPTION
`prefix + R` is currently bound to sourcing `~/.tmux.conf`.
For anyone using `~/.config/tmux/tmux.conf` or `${XDG_CONFIG_HOME}/tmux/tmux.conf`,
this binding will be of no use, perhaps even misleading.

This patch tests if the file `${XDG_CONFIG_HOME:-$HOME/.config}/tmux/tmux.conf` exists,
if affirmative, it sources it, if not, it sources `~/.tmux.conf`.