### PR TITLE
Evaluate XDG_CONFIG_HOME according to XDG Base Directory Specification

### DIFF
--- a/sensible.tmux
+++ b/sensible.tmux
@@ -68,10 +68,16 @@ get_tmux_config() {
 	local tmux_config_xdg="${XDG_CONFIG_HOME:-$HOME/.config}/tmux/tmux.conf"
 	local tmux_config="$HOME/.tmux.conf"
 
-	if [ -f "${tmux_config_xdg}" ]; then
-		echo "${tmux_config_xdg}"
+	if [ -n "${XDG_CONFIG_HOME}" ]; then
+		if [ -f "${tmux_config_xdg}" ]; then
+			echo "${tmux_config_xdg}"
+		fi
 	else
-		echo ${tmux_config}
+		if [ -f "${tmux_config}" ]; then
+			echo "${tmux_config}"
+		else
+			echo "$HOME/.config/tmux/tmux.conf"
+		fi
 	fi
 }
 


### PR DESCRIPTION
[XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/latest/ar01s03.html) says that:
If $XDG_CONFIG_HOME is either not set or empty, a default equal to $HOME/.config should be used.

A small and simple edit.