### PR TITLE
Fix bug with escape-time 0

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ Tested and working on Linux, OSX and Cygwin.
 ### Options
 
 ```tmux
-# Address vim mode switching delay (http://superuser.com/a/252717/65504)
-set -s escape-time 0
+# Address vim mode switching delay (https://superuser.com/a/252717) (https://superuser.com/a/1809494)
+set -s escape-time 5
 
 # Increase scrollback buffer size from 2000 to 50000 lines
 set -g history-limit 50000

--- a/sensible.tmux
+++ b/sensible.tmux
@@ -80,7 +80,7 @@ main() {
 
 	# address vim mode switching delay (http://superuser.com/a/252717/65504)
 	if server_option_value_not_changed "escape-time" "500"; then
-		tmux set-option -s escape-time 0
+		tmux set-option -s escape-time 5
 	fi
 
 	# increase scrollback buffer size


### PR DESCRIPTION
[Rationale](https://superuser.com/a/1809494):

> `escape-time 0` prevents tmux from recognizing escape sequences that are fragmented across read/packet boundaries. You should raise that to a more reasonable value such as 100ms which should be enough time for most cases while still being quick enough that it shouldn't cause human-scale interaction issues.